### PR TITLE
DOCS: typo and mdfile fixing.

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -6,17 +6,20 @@ Este guia visa mostrar como iniciar, rodar, testar e preparar esse projeto para 
 ## Como contribuir?
 
 ### Requisitos
+
 Para trabalhar com o projeto voce precisa do seguinte conjunto ferramental:
+
 * Python 3.10+; (inicialmente suportamos apenas a última versão disponível do python);
-  * Caso queira, voce pode usar um gerenciador de dependencias python. Recomendamos o [Pyenv](https://github.com/pyenv/pyenv). Ele conversa bem com o Poetry;
+  * Caso queira, voce pode usar um gerenciador de dependências python. Recomendamos o [Pyenv](https://github.com/pyenv/pyenv). Ele conversa bem com o Poetry;
 * [Poetry](https://python-poetry.org/) (Responsável por gerenciar o projeto, servindo de ponte de comunicação com o PyPI)
 
 ### Primeiro setup
-1. Uma vez que voce clonou o projeto instale as dependencias para começar o trabalho;
+
+1. Uma vez que voce clonou o projeto instale as dependências para começar o trabalho;
 
    ```bash
     $ poetry install --with dev
-   ```
+
     Creating virtualenv brasilapy-L06DoqL8-py3.10 in /Users/jon/Library/Caches/pypoetry/virtualenvs
     Installing dependencies from lock file
 
@@ -58,20 +61,21 @@ Para trabalhar com o projeto voce precisa do seguinte conjunto ferramental:
     • Installing types-requests (2.28.11)
 
     Installing the current project: brasilapy (1.2.0)
+   ```
 
 2. Instale o wrapper do `pre-commit`. Ele te ajudará a verificar seu código antes de cada commit. Caso tenha curiosidade sobre o projeto, voce pode achar no site oficial em [https://pre-commit.com/](https://pre-commit.com/).
 
     ```bash
     $ poetry shell  # Isso entra dentro do virtualenv, onde o pre-commit está.
-    ```
     Spawning shell within /Users/jon/Library/Caches/pypoetry/virtualenvs/brasilapy-L06DoqL8-py3.10
 
-    (brasilapy-py3.10) 
+    (brasilapy-py3.10)
+    ```
+
     ```bash
     $ pre-commit install
-    ```
     pre-commit installed at .git/hooks/pre-commit
-
+    ```
 
 3. Agora só apontar para sua IDE favorita e voce está pronto para iniciar os trabalhos. =)
 
@@ -79,57 +83,59 @@ Para trabalhar com o projeto voce precisa do seguinte conjunto ferramental:
 
 Para testar o projeto, é bem simples. Uma vez que voce estiver com o virtual environment do projeto ativado, rode o seguinte comando
 
-    
-    $ poetry shell  # Isso ativa o shell do python para o virtual environment
-    (brasilapy-py3.10) $ pytest --cov
-    ====================================== test session starts ======================================
-    platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
-    rootdir: /Users/jon/Developer/opensource/brasilapi_testing
-    plugins: cov-3.0.0
-    collected 31 items
+```bash
+$ poetry shell  # Isso ativa o shell do python para o virtual environment
+(brasilapy-py3.10) $ pytest --cov
+====================================== test session starts ======================================
+platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
+rootdir: /Users/jon/Developer/opensource/brasilapi_testing
+plugins: cov-3.0.0
+collected 31 items
 
-    tests/test_processor.py ....                                                              [ 12%]
-    tests/test_utils.py ..                                                                    [ 19%]
-    tests/banks/test_banks.py ..                                                              [ 25%]
-    tests/cep/test_cep.py .....                                                               [ 41%]
-    tests/cnpj/test_cnpj.py ..                                                                [ 48%]
-    tests/ddd/test_ddd.py ..                                                                  [ 54%]
-    tests/feriados/test_feriados.py ..                                                        [ 61%]
-    tests/fipe/test_fipe.py ...                                                               [ 70%]
-    tests/ibge/test_ibge.py .....                                                             [ 87%]
-    tests/registro_br/test_registro_br.py ..                                                  [ 93%]
-    tests/taxas/test_taxas.py ..                                                              [100%]
+tests/test_processor.py ....                                                              [ 12%]
+tests/test_utils.py ..                                                                    [ 19%]
+tests/banks/test_banks.py ..                                                              [ 25%]
+tests/cep/test_cep.py .....                                                               [ 41%]
+tests/cnpj/test_cnpj.py ..                                                                [ 48%]
+tests/ddd/test_ddd.py ..                                                                  [ 54%]
+tests/feriados/test_feriados.py ..                                                        [ 61%]
+tests/fipe/test_fipe.py ...                                                               [ 70%]
+tests/ibge/test_ibge.py .....                                                             [ 87%]
+tests/registro_br/test_registro_br.py ..                                                  [ 93%]
+tests/taxas/test_taxas.py ..                                                              [100%]
 
-    ---------- coverage: platform darwin, python 3.10.6-final-0 ----------
-    Name                          Stmts   Miss  Cover
-    -------------------------------------------------
-    brasilapy/__init__.py             1      0   100%
-    brasilapy/client.py              76      0   100%
-    brasilapy/constants.py           15      0   100%
-    brasilapy/exceptions.py           7      0   100%
-    brasilapy/models/cnpj.py         69      0   100%
-    brasilapy/models/general.py      75      0   100%
-    brasilapy/processor.py           18      0   100%
-    brasilapy/utils.py                3      0   100%
-    -------------------------------------------------
-    TOTAL                           264      0   100%
+---------- coverage: platform darwin, python 3.10.6-final-0 ----------
+Name                          Stmts   Miss  Cover
+-------------------------------------------------
+brasilapy/__init__.py             1      0   100%
+brasilapy/client.py              76      0   100%
+brasilapy/constants.py           15      0   100%
+brasilapy/exceptions.py           7      0   100%
+brasilapy/models/cnpj.py         69      0   100%
+brasilapy/models/general.py      75      0   100%
+brasilapy/processor.py           18      0   100%
+brasilapy/utils.py                3      0   100%
+-------------------------------------------------
+TOTAL                           264      0   100%
 
 
-    ====================================== 31 passed in 0.10s =======================================
+====================================== 31 passed in 0.10s =======================================
+```
 
 ### Criando um PR
 
-1. Uma vez que voce está no projeto, crie uma branch com a funcionalidade que deseja desenvolver. Não possuimos um padrão, mas acho que seria bom utilizarmos uma notação para as branches da seguinte forma:
+1. Uma vez que voce está no projeto, crie uma branch com a funcionalidade que deseja desenvolver. Não possuímos um padrão, mas acho que seria bom utilizarmos uma notação para as branches da seguinte forma:
 
-* feature/add_some_feature
-* bugfix/fix_something_on_a_feature
+    * feature/add_some_feature
+    * bugfix/fix_something_on_a_feature
 
 2. Crie e ou edite os arquivos normalmente.
 3. Adicione os arquivos e faça o `commit` de acordo. O pre-commit irá executar e validar seu commit.
-   a. Caso queira, voce pode rodar o precommit manualmente usando `pre-commit run --all-files`.
+    a. Caso queira, voce pode rodar o pre-commit manualmente usando `pre-commit run --all-files`.
 
 4. Ao fazer o push para seu repositório, só criar um PR, descrever o que voce gostaria de resolver ou adicionar e aguardar pelas pipelines de validação serem executadas.
 
 ## Dúvidas?
+
 Caso ainda reste alguma dúvida, só criar uma Issue que iremos ajudá-lo.
 Obrigado e aguardamos suas contribuições. =)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-![](./images/brasilapi-logo-small.png) <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" width="70" height="70" />
+
+![logo](./images/brasilapi-logo-small.png) <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" width="70" height="70" />
 
 # BrasilApy
+
 Um cliente da [Brasil  API](https://brasilapi.com.br/) em python3. Link do [repositório](https://github.com/BrasilAPI/BrasilAPI) oficial.
 
 [![codecov](https://codecov.io/gh/joepreludian/brasilapy/branch/master/graph/badge.svg?token=BKYR6XTW4N)](https://codecov.io/gh/joepreludian/brasilapy)
@@ -8,16 +10,19 @@ Um cliente da [Brasil  API](https://brasilapi.com.br/) em python3. Link do [repo
 
 Nesta versão `1.0.0` esse cliente possui suporte a autocomplete por meio de Typed Hints. Todos as respostas são traduzidas para objetos do Pydantic, que trazem previsibilidade ao explorar a API  através da sua IDE favorita.
 
-![](./images/autocomplete.png)
+![autocomplete](./images/autocomplete.png)
 
 ## Instalação
+
 Rode o comando `pip install brasilapy` e estará tudo pronto.
-A versão do python que é compativel com essa biblioteca é a `3.10+`.
+A versão do python que é compatível com essa biblioteca é a `3.10+`.
 
 ## Documentação
+
 Documentação oficial da API com todas as chamadas poderão se encontradas [neste link](https://brasilapi.com.br/docs).
 
 ### Código de exemplo
+
 Para efetuar as consultas na API, basta instanciar a classe e fazer as consultas.
 
 ```py
@@ -46,20 +51,20 @@ for municipio in municipios:
 
 | Método                                                                    | Detalhes |
 |---------------------------------------------------------------------------|----------|
- | get_banks()                                                               |          |
- | get_bank(code: str)                                                       |          |
- | get_cep(test_cep: str, api_version: APIVersion)                                |          |
- | get_cnpj(test_cnpj: str)                                                       |          |
- | get_ddd(test_ddd: str)                                                         |          |
- | get_feriados(year: int)                                                   |          |
- | get_fipe_veiculos(tipo_veiculos: FipeTipoVeiculo, tabela_referencia: int) |          |
- | get_fipe_precos(codigo_fipe: str, tabela_referencia: int)                 |          |
- | get_fipe_tabelas()                                                        |          |
- | get_ibge_municipios(state_uf: str, providers: tuple\[IBGEProvider\]       |          |
- | get_ibge_estados()                                                        |          |
- | get_registro_br_domain(fqdn: str)                                         |          |
- | get_taxas_juros()                                                         |          |
- | get_taxa_juros(taxa: TaxaJurosType)                                       |          |
+| get_banks()                                                               |          |
+| get_bank(code: str)                                                       |          |
+| get_cep(test_cep: str, api_version: APIVersion)                           |          |
+| get_cnpj(test_cnpj: str)                                                  |          |
+| get_ddd(test_ddd: str)                                                    |          |
+| get_feriados(year: int)                                                   |          |
+| get_fipe_veiculos(tipo_veiculos: FipeTipoVeiculo, tabela_referencia: int) |          |
+| get_fipe_precos(codigo_fipe: str, tabela_referencia: int)                 |          |
+| get_fipe_tabelas()                                                        |          |
+| get_ibge_municipios(state_uf: str, providers: tuple\[IBGEProvider\])      |          |
+| get_ibge_estados()                                                        |          |
+| get_registro_br_domain(fqdn: str)                                         |          |
+| get_taxas_juros()                                                         |          |
+| get_taxa_juros(taxa: TaxaJurosType)                                       |          |
 
 Os tipos de dados `APIVersion`, `FipeTipoVeiculo`, `IBGEProvider` e `TaxaJurosType` são classes de constants que podem ser importadas através do seguinte comando:
 

--- a/brasilapy/exceptions.py
+++ b/brasilapy/exceptions.py
@@ -3,7 +3,7 @@ class ProcessorException(Exception):
         self,
         status_code: int,
         response_text: str,
-        message: str = "A problem occured when processing your request",
+        message: str = "A problem occurred when processing your request.",
     ):
         self.status_code = status_code
         self.response_text = response_text

--- a/brasilapy/processor.py
+++ b/brasilapy/processor.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 import requests
 from requests import Session as RequestSession
@@ -7,8 +8,7 @@ from brasilapy.exceptions import ProcessorException
 
 
 class ClientProcessor(ABC):
-
-    handler: any
+    handler: Any
     base_url: str
 
     @abstractmethod


### PR DESCRIPTION
- foi utilizado a extensão markdownlint (https://github.com/DavidAnson/markdownlint/tree/v0.29.0) para padronizar os arquivos .md.
- E uma extensão do Code Spell Checker (https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker-portuguese-brazilian) para encontrar erros gramaticais.