### PR TITLE
bugfix: pydantic raise error when empty string 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ default_language_version:
 files: ".*$"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       # See https://pre-commit.com/hooks.html for more hooks
       - id: check-ast
@@ -19,12 +19,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/bandit
-    rev: 1.7.4
+    rev: 1.7.5
     hooks:
       - id: bandit
         args: [ '-iii', '-ll' ]
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies: [
@@ -35,11 +35,11 @@ repos:
           "flake8-simplify",
         ]
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/brasilapy/client.py
+++ b/brasilapy/client.py
@@ -149,8 +149,10 @@ class BrasilAPI:
         return [TaxaJuros.parse_obj(taxa) for taxa in taxas]
 
     def get_taxa_juros(self, taxa: TaxaJurosType) -> TaxaJuros:
-        taxa = self.processor.get_data(f"/taxas/v1/{taxa}")
-        return TaxaJuros.parse_obj(taxa)
+        if len(taxa) == 0:
+            raise ValueError("The 'taxa' must be a valid TaxaJurosType.")
+        taxa_json = self.processor.get_data(f"/taxas/v1/{taxa}")
+        return TaxaJuros.parse_obj(taxa_json)
 
     def get_ncms(self) -> list[NCM]:
         ncms = self.processor.get_data("/ncm/v1/")

--- a/brasilapy/client.py
+++ b/brasilapy/client.py
@@ -3,6 +3,7 @@ from brasilapy.models.cnpj import CNPJ
 from brasilapy.models.general import (
     CEP,
     DDD,
+    NCM,
     Bank,
     CEPv2,
     FeriadoNacional,
@@ -13,13 +14,11 @@ from brasilapy.models.general import (
     IbgeMunicipio,
     RegistroBrDominio,
     TaxaJuros,
-    NCM
 )
 from brasilapy.processor import RequestsProcessor
 
 
 class BrasilAPI:
-
     processor: RequestsProcessor
 
     def __init__(self, processor_handler: RequestsProcessor = RequestsProcessor):
@@ -35,7 +34,6 @@ class BrasilAPI:
         return Bank.parse_obj(bank_response)
 
     def get_cep(self, cep: str, api_version: APIVersion = APIVersion.V1) -> CEP | CEPv2:
-
         if len(cep) != 8:
             raise TypeError("Please provide a valid CEP number")
 
@@ -107,7 +105,6 @@ class BrasilAPI:
             IBGEProvider.WIKIPEDIA,
         ),
     ) -> list[IbgeMunicipio]:
-
         if not providers:
             raise TypeError("A list of providers must be defined")
 
@@ -154,15 +151,18 @@ class BrasilAPI:
     def get_taxa_juros(self, taxa: TaxaJurosType) -> TaxaJuros:
         taxa = self.processor.get_data(f"/taxas/v1/{taxa}")
         return TaxaJuros.parse_obj(taxa)
-    
+
     def get_ncms(self) -> list[NCM]:
-        ncms = self.processor.get_data(f"/ncm/v1/")
+        ncms = self.processor.get_data("/ncm/v1/")
         return [NCM.parse_obj(ncm) for ncm in ncms]
 
     def get_ncm(self, codigo: str) -> NCM:
+        if len(codigo) == 0:
+            raise ValueError("The NCM code must not be empty.")
+
         ncm = self.processor.get_data(f"/ncm/v1/{codigo}")
         return NCM.parse_obj(ncm)
-    
+
     def get_ncm_descricao(self, descricao: str) -> list[NCM]:
         ncms = self.processor.get_data(f"/ncm/v1?search={descricao}")
         return [NCM.parse_obj(ncm) for ncm in ncms]

--- a/brasilapy/client.py
+++ b/brasilapy/client.py
@@ -21,7 +21,7 @@ from brasilapy.processor import RequestsProcessor
 class BrasilAPI:
     processor: RequestsProcessor
 
-    def __init__(self, processor_handler: RequestsProcessor = RequestsProcessor):
+    def __init__(self, processor_handler: type[RequestsProcessor] = RequestsProcessor):
         self.processor = processor_handler()
 
     def get_banks(self) -> list[Bank]:
@@ -56,7 +56,7 @@ class BrasilAPI:
         cnpj_details: dict = self.processor.get_data(f"/cnpj/v1/{cnpj}")
         return CNPJ.parse_obj(cnpj_details)
 
-    def get_ddd(self, ddd: str):
+    def get_ddd(self, ddd: str) -> DDD:
         if len(ddd) != 2:
             raise TypeError("Please provide a DDD number (2 digits)")
 
@@ -99,7 +99,7 @@ class BrasilAPI:
     def get_ibge_municipios(
         self,
         state_uf: str,
-        providers: tuple[IBGEProvider] = (
+        providers: tuple[IBGEProvider, ...] = (
             IBGEProvider.DADOS_ABERTOS_BR,
             IBGEProvider.GOV,
             IBGEProvider.WIKIPEDIA,

--- a/tests/ncm/test_ncms.py
+++ b/tests/ncm/test_ncms.py
@@ -1,19 +1,18 @@
-from unittest import mock
 from datetime import datetime
+from unittest import mock
+
+import pytest
 
 from brasilapy import BrasilAPI
 from brasilapy.models.general import NCM
 
 
 class TestNCM:
-
     def test_get_ncms(self, brasil_api: BrasilAPI, ncm_json):
-
         with mock.patch(
             "brasilapy.client.RequestsProcessor.get_data",
             return_value=ncm_json,
         ) as get_data_mock:
-
             ncms = brasil_api.get_ncms()
 
             get_data_mock.assert_called_once()
@@ -39,12 +38,10 @@ class TestNCM:
             assert ncms[0].ano_ato == ncm_json[0].get("ano_ato")
 
     def test_get_ncm(self, brasil_api: BrasilAPI, ncm_json):
-
         with mock.patch(
             "brasilapy.client.RequestsProcessor.get_data",
             return_value=ncm_json[0],
         ) as get_data_mock:
-
             ncm = brasil_api.get_ncm(codigo="01")
 
             get_data_mock.assert_called_once()
@@ -59,7 +56,7 @@ class TestNCM:
 
             assert ncm.dict() == ncm_json[0]
             assert type(ncm) is NCM
-            
+
             assert ncm.codigo == ncm_json[0].get("codigo")
             assert ncm.descricao == ncm_json[0].get("descricao")
             assert ncm.data_inicio == ncm_json[0].get("data_inicio")
@@ -68,13 +65,20 @@ class TestNCM:
             assert ncm.numero_ato == ncm_json[0].get("numero_ato")
             assert ncm.ano_ato == ncm_json[0].get("ano_ato")
 
-    def test_ncm_descricao(self, brasil_api: BrasilAPI, ncm_json):
+    def test_cnm_with_invalid_code(self, brasil_api: BrasilAPI, ncm_json):
+        with mock.patch(
+            "brasilapy.client.RequestsProcessor.get_data",
+            return_value=ncm_json[0],
+        ):
+            with pytest.raises(ValueError) as exc:
+                brasil_api.get_ncm(codigo="")
+            assert "The NCM code must not be empty." in str(exc)
 
+    def test_ncm_descricao(self, brasil_api: BrasilAPI, ncm_json):
         with mock.patch(
             "brasilapy.client.RequestsProcessor.get_data",
             return_value=ncm_json,
         ) as get_data_mock:
-
             ncms = brasil_api.get_ncm_descricao(descricao="Animais vivos.")
 
             get_data_mock.assert_called_once()
@@ -89,7 +93,7 @@ class TestNCM:
 
             assert len(ncms) == len(ncm_json)
             assert type(ncms[0]) is NCM
-            
+
             assert ncms[0].codigo == ncm_json[0].get("codigo")
             assert ncms[0].descricao == ncm_json[0].get("descricao")
             assert ncms[0].data_inicio == ncm_json[0].get("data_inicio")

--- a/tests/taxas/test_taxas.py
+++ b/tests/taxas/test_taxas.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from brasilapy import BrasilAPI
 from brasilapy.constants import TaxaJurosType
 from brasilapy.models.general import TaxaJuros
@@ -7,25 +9,32 @@ from brasilapy.models.general import TaxaJuros
 
 class TestTaxas:
     def test_get_taxas(self, brasil_api: BrasilAPI, taxas_json):
-
         with mock.patch(
             "brasilapy.client.RequestsProcessor.get_data",
             return_value=taxas_json,
         ):
-
             taxas = brasil_api.get_taxas_juros()
 
             assert type(taxas[0]) is TaxaJuros
             assert taxas[0].dict() == taxas_json[0]
 
     def test_taxa_per_type(self, brasil_api: BrasilAPI, taxas_json):
-
         with mock.patch(
             "brasilapy.client.RequestsProcessor.get_data",
             return_value=taxas_json[0],
         ):
-
             taxa = brasil_api.get_taxa_juros(taxa=TaxaJurosType.SELIC)
 
             assert type(taxa) is TaxaJuros
             assert taxa.dict() == taxas_json[0]
+
+    def test_taxa_per_type_with_invalid_tax_type(
+        self, brasil_api: BrasilAPI, taxas_json
+    ):
+        with mock.patch(
+            "brasilapy.client.RequestsProcessor.get_data",
+            return_value=taxas_json[0],
+        ):
+            with pytest.raises(ValueError) as exc:
+                brasil_api.get_taxa_juros(taxa="")
+            assert "The 'taxa' must be a valid TaxaJurosType." in str(exc)


### PR DESCRIPTION
- [X] Arrumar type hints.
- [X] Arrumar métodos get com parâmetros e modificar o teste.
- [ ] Adicionar testes para métodos com outros tipos de parâmetros?

## Motivo
O uso do metodo get_ncm(codigo) com código="" é o equivalente ao usar a endpoint do get_ncms().

Em get_ncm:

```py
ncm = self.processor.get_data(f"/ncm/v1/{codigo}")
```

Em get_ncms:

```py
ncm = self.processor.get_data("/ncm/v1/")
```

O get_data recebe uma lista, e o erro é levantado pelo validator do pydantic.

## Métodos que foram modificados

- ncm.
- taxa.

## Outros métodos com potencial de levantar erros (se modificados)

- com parâmetro do tipo inteiro:
  str(numero_inteiro) sempre retorna pelo menos um character. ex: 0, 1, -5

- método que possui a Guard Clause "if not x: raise SomeError()"
  O "not x" retorna True para x, "", 0, [], {}.
  